### PR TITLE
Add support for converting numpy integers.

### DIFF
--- a/monetdblite/monetize.py
+++ b/monetdblite/monetize.py
@@ -8,6 +8,11 @@ import datetime
 import decimal
 import sys
 
+try:
+    import numpy
+except ImportError:
+    raise Exception('MonetDBLite requires numpy but import of numpy failed')
+
 PY3 = sys.version_info[0] >= 3
 
 from monetdblite.exceptions import ProgrammingError
@@ -72,6 +77,7 @@ mapping = [
     (str, monet_escape),
     (bytes, monet_bytes),
     (int, str),
+    (numpy.integer, str),
     (complex, str),
     (float, str),
     (decimal.Decimal, str),


### PR DESCRIPTION
Currently, reflecting MetaData using sqlalchemy-monetdb with monetdblite doesn't work.

For example:

```python
from sqlalchemy import create_engine, MetaData, Table

engine = create_engine('monetdb+lite:///:memory', echo=True)
metadata = MetaData(bind=engine)
query = """
CREATE TABLE "test" (
    id int,
    data varchar(128)
)
"""
engine.execute(query)
metadata = MetaData(bind=engine)
tbl = Table('test', metadata, autoload=True)
```

This happens because when sqlalchemy-monetdb tries to round trip integer ids, they are coming back from monetdblite as numpy.int32, and this isn't supported by monetize.convert.

This adds support for that.  I think the fix should be in monetdblite rather than sqlalchemy-monetdb, a user will expect that data types retrieved from the driver should be able to round trip back in a query.